### PR TITLE
Add Node.GetContext method

### DIFF
--- a/node.go
+++ b/node.go
@@ -83,6 +83,10 @@ func (node *Node) useWebDefaults() {
 	node.StyleSetAlignContent(AlignStretch)
 }
 
+func (node *Node) GetContext() interface{} {
+	return node.context_
+}
+
 // GetHasNewLayout
 func (node *Node) GetHasNewLayout() bool {
 	return node.hasNewLayout_


### PR DESCRIPTION
Complements the Node.SetContext method.

fixes #3